### PR TITLE
makefile: clean target also removes .terraform directories

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Draft next release
         uses: release-drafter/release-drafter@v5
         with:
-          publish: ${{ !contains(steps.get-merged-pull-requests.outputs.labels, 'no-release' )}}
+          publish: ${{ !contains(steps.get-merged-pull-requests.outputs.labels, 'no-release') }}
           prerelease: false
           config-name: auto-release.yml
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean test
 
 clean:
-	@find . \( -name .terraform.lock.hcl -type f \) | xargs rm -rfv
+	@find . \( -name .terraform.lock.hcl -type f \) -o \( -name .terraform -type d \)| xargs rm -rfv
 
 test:
 	make -C test


### PR DESCRIPTION
## what

- update `clean` target to remove `.terraform` directories

## why

- So that `clean` removes more files that are not checked into source control
